### PR TITLE
Update attribute source an dupdate api protection client

### DIFF
--- a/ibmsecurity/isam/aac/api_protection/clients.py
+++ b/ibmsecurity/isam/aac/api_protection/clients.py
@@ -76,7 +76,7 @@ def generate_client_secret(isamAppliance, check_mode=False, force=False):
 
 def add(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
         contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None,
-        requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
+        requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, extProperties=None, check_mode=False,
         force=False):
     """
     Create an API protection definition
@@ -151,6 +151,14 @@ def add(isamAppliance, name, definitionName, companyName, redirectUri=None, comp
                 else:
                     client_json["jwksUri"] = jwksUri
 
+            if extProperties is not None:
+                if tools.version_compare(isamAppliance.facts["version"], "9.0.5.0") < 0:
+                    warnings.append(
+                        "Appliance at version: {0}, extProperties: {1} is not supported. Needs 9.0.5.0 or higher. Ignoring extProperties for this call.".format(
+                            isamAppliance.facts["version"], extProperties))
+                else:
+                    client_json["extProperties"] = extProperties
+
             return isamAppliance.invoke_post(
                 "Create an API protection definition", uri, client_json, requires_modules=requires_modules,
                 requires_version=requires_version, warnings=warnings)
@@ -181,7 +189,7 @@ def delete(isamAppliance, name, check_mode=False, force=False):
 
 def update(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
            contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None,
-           requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
+           requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, extProperties=None, check_mode=False,
            force=False, new_name=None):
     """
     Update a specified mapping rule
@@ -291,6 +299,16 @@ def update(isamAppliance, name, definitionName, companyName, redirectUri=None, c
         elif 'jwksUri' in ret_obj['data']:
             del ret_obj['data']['jwksUri']
 
+        if extProperties is not None:
+            if tools.version_compare(isamAppliance.facts["version"], "9.0.5.0") < 0:
+                warnings.append(
+                    "Appliance at version: {0}, extProperties: {1} is not supported. Needs 9.0.5.0 or higher. Ignoring extProperties for this call.".format(
+                        isamAppliance.facts["version"], extProperties))
+            else:
+                json_data["extProperties"] = extProperties
+        elif 'extProperties' in ret_obj['data']:
+            del ret_obj['data']['extProperties']
+
         sorted_ret_obj = tools.json_sort(ret_obj['data'])
         sorted_json_data = tools.json_sort(json_data)
         logger.debug("Sorted Existing Data:{0}".format(sorted_ret_obj))
@@ -311,7 +329,7 @@ def update(isamAppliance, name, definitionName, companyName, redirectUri=None, c
 
 def set(isamAppliance, name, definitionName, companyName, redirectUri=None, companyUrl=None, contactPerson=None,
         contactType=None, email=None, phone=None, otherInfo=None, clientId=None, clientSecret=None, new_name=None,
-        requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, check_mode=False,
+        requirePkce=None, encryptionDb=None, encryptionCert=None, jwksUri=None, extProperties=None, check_mode=False,
         force=False):
     """
     Creating or Modifying an API Protection Definition
@@ -322,7 +340,7 @@ def set(isamAppliance, name, definitionName, companyName, redirectUri=None, comp
         return add(isamAppliance, name, definitionName, companyName, redirectUri=redirectUri, companyUrl=companyUrl,
                    contactPerson=contactPerson, contactType=contactType, email=email, phone=phone, otherInfo=otherInfo,
                    clientId=clientId, clientSecret=clientSecret, requirePkce=requirePkce, encryptionDb=encryptionDb,
-                   encryptionCert=encryptionCert, jwksUri=jwksUri, check_mode=check_mode, force=True)
+                   encryptionCert=encryptionCert, jwksUri=jwksUri, extProperties=extProperties, check_mode=check_mode, force=True)
     else:
         # Update request
         logger.info("Definition {0} exists, requesting to update.".format(name))
@@ -330,7 +348,7 @@ def set(isamAppliance, name, definitionName, companyName, redirectUri=None, comp
                       contactPerson=contactPerson, contactType=contactType, email=email, phone=phone,
                       otherInfo=otherInfo, clientId=clientId, clientSecret=clientSecret, new_name=new_name,
                       requirePkce=requirePkce, encryptionDb=encryptionDb, encryptionCert=encryptionCert,
-                      jwksUri=jwksUri, check_mode=check_mode, force=force)
+                      jwksUri=jwksUri, extProperties=extProperties, check_mode=check_mode, force=force)
 
 
 def compare(isamAppliance1, isamAppliance2):

--- a/ibmsecurity/isam/fed/attribute_source.py
+++ b/ibmsecurity/isam/fed/attribute_source.py
@@ -40,7 +40,7 @@ def _get(isamAppliance, id):
     :return:
     """
     return isamAppliance.invoke_get("Retrieve a specific attribute source",
-                                    "{0}/{2}".format(uri, id),
+                                    "{0}/{1}".format(uri, id),
                                     requires_modules=requires_modules,
                                     requires_version=requires_version)
 


### PR DESCRIPTION
Update two files:
isam/fed/attribute_source.py: changed line 43 to change {2} to {1}

isam/aac/api_protection/clients.py to add new parameter support: extProperties for ISAM 9.0.5 support